### PR TITLE
フリーワード検索の実装

### DIFF
--- a/frontend/src/components/SearchContainer.tsx
+++ b/frontend/src/components/SearchContainer.tsx
@@ -214,6 +214,13 @@ export default function SearchContainer({ episodes }: SearchContainerProps) {
 
   const displayedEpisodes = sortedEpisodes.slice(0, displayCount);
   const hasMore = displayCount < sortedEpisodes.length;
+  const hasActiveFilters = Boolean(
+    conditions.member1 ||
+    conditions.member2 ||
+    conditions.episode ||
+    conditions.year ||
+    conditions.caption.trim()
+  );
 
   return (
     <Container maxWidth="md" sx={{ py: 4 }}>
@@ -237,9 +244,7 @@ export default function SearchContainer({ episodes }: SearchContainerProps) {
               pl: 2,
             }}
           >
-            {conditions.member1 || conditions.member2 || conditions.episode || conditions.year || conditions.caption.trim()
-              ? "検索結果"
-              : "最新エピソード"}
+            {hasActiveFilters ? `検索結果 (${filteredEpisodes.length}件)` : "最新エピソード"}
           </Typography>
           <Box sx={{ display: "flex", gap: 1 }}>
             <Button

--- a/frontend/src/components/SearchContainer.tsx
+++ b/frontend/src/components/SearchContainer.tsx
@@ -25,6 +25,7 @@ export default function SearchContainer({ episodes }: SearchContainerProps) {
     member2: "",
     episode: "",
     year: "",
+    caption: "",
   });
 
   const [displayCount, setDisplayCount] = useState(10);
@@ -62,6 +63,7 @@ export default function SearchContainer({ episodes }: SearchContainerProps) {
       member2: "",
       episode: "",
       year: "",
+      caption: "",
     });
     setDisplayCount(10);
   };
@@ -191,6 +193,11 @@ export default function SearchContainer({ episodes }: SearchContainerProps) {
       if (conditions.member2 && !ep.members.includes(conditions.member2)) {
         return false;
       }
+      // captionでフリーワード検索
+      const searchWord = conditions.caption.trim().toLowerCase();
+      if (searchWord && !ep.caption.toLowerCase().includes(searchWord)) {
+        return false;
+      }
 
       return true;
     });
@@ -230,7 +237,7 @@ export default function SearchContainer({ episodes }: SearchContainerProps) {
               pl: 2,
             }}
           >
-            {conditions.member1 || conditions.member2 || conditions.episode || conditions.year
+            {conditions.member1 || conditions.member2 || conditions.episode || conditions.year || conditions.caption.trim()
               ? "検索結果"
               : "最新エピソード"}
           </Typography>

--- a/frontend/src/components/SearchForm.tsx
+++ b/frontend/src/components/SearchForm.tsx
@@ -11,6 +11,7 @@ import {
   Select,
   MenuItem,
   ListSubheader,
+  TextField,
 } from "@mui/material";
 import type { SearchConditions } from "@/types/search";
 import type { GroupedMembers } from "./SearchContainer";
@@ -146,6 +147,18 @@ export default function SearchForm({
               ))}
             </Select>
           </FormControl>
+        </Grid2>
+
+        {/* フリーワード */}
+        <Grid2 size={{ xs: 12, md: 12 }}>
+          <TextField
+            fullWidth
+            id="caption-search"
+            label="フリーワード"
+            value={conditions.caption}
+            onChange={(e) => onConditionChange("caption", e.target.value)}
+            placeholder="フリー検索"
+          />
         </Grid2>
       </Grid2>
 

--- a/frontend/src/types/search.ts
+++ b/frontend/src/types/search.ts
@@ -3,4 +3,5 @@ export interface SearchConditions {
   member2: string;
   episode: string;
   year: string;
+  caption: string;
 }


### PR DESCRIPTION
# チェックリスト

| No. | 優先度 | 観点 | チェック項目 | 結果 |
| --- | --- | --- | --- | --- |
| 1 | Must | 必須要件（issue #11） | フリーワード入力で Enter なしに結果が更新される | OK |
| 2 | Must | 必須要件（issue #11） | 「検索結果をクリアする」でフリーワードを含む全条件が初期化される | OK |
| 3 | Must | 必須要件（issue #11） | クリア後、見出しが「最新エピソード」に戻る | OK |
| 4 | Must | 一致仕様 | 部分一致でヒットする | OK |
| 5 | Must | 一致仕様 | 前後空白ありでも同じ結果（trim） | OK |
| 6 | Must | 一致仕様 | 英字の大文字小文字で結果が変わらない | OK |
| 7 | Must | 複合条件（AND） | フリーワード + メンバー1 | OK |
| 8 | Must | 複合条件（AND） | フリーワード + 配信年 | OK |
| 9 | Must | 複合条件（AND） | フリーワード + エピソード範囲 | OK |
| 10 | Must | 回帰確認 | 0件検索でもUI崩れなし | OK |
| 11 | Should | 一致仕様 | 複数語入力は分割せず1文字列として判定される | OK |
| 12 | Should | 回帰確認 | 昇順/降順切り替えが正常 | OK |
| 13 | Should | 回帰確認 | 「もっと表示する」が正常 | OK |
| 14 | Should | レスポンシブ・入力 | モバイル幅でレイアウト崩れなし | OK |
| 15 | Should | レスポンシブ・入力 | 日本語IME確定後に正しく検索更新される | OK |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * エピソードのキャプション（字幕・説明文）でのフリーワード検索を追加しました。
  * 検索フォームに「フリーワード」入力を追加し、入力で結果を絞り込めます（プレースホルダあり）。
  * 検索のクリア／リセットにフリーワード条件が含まれるようになり、フィルタ適用時は結果ヘッダに件数を表示します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->