### PR TITLE
OGP設定の追加

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -14,7 +14,7 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://sakumimidb.example.com";
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://sakumimi-db.vercel.app";
 
 export const metadata: Metadata = {
   title: "SakumimiDB",

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v13-appRouter";
+import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/providers/ThemeProvider";
@@ -13,9 +14,39 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-export const metadata = {
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://sakumimidb.example.com";
+
+export const metadata: Metadata = {
   title: "SakumimiDB",
-  description: "櫻坂46のWEBラジオ「さくみみ」の検索用アプリケーションです",
+  description: "櫻坂46のWEBラジオ「さくみみ」の検索用アプリケーション",
+  
+  // OGP設定
+  openGraph: {
+    title: "SakumimiDB",
+    description:
+      "櫻坂46のWEBラジオ「さくみみ」の検索用アプリケーション",
+    url: baseUrl,
+    type: "website",
+    locale: "ja_JP",
+    images: [
+      {
+        url: `${baseUrl}/logo.png`,
+        width: 1200,
+        height: 630,
+        alt: "SakumimiDB - 櫻坂46 さくみみ検索アプリケーション",
+        type: "image/png",
+      },
+    ],
+  },
+  
+  // Twitter Card設定
+  twitter: {
+    card: "summary_large_image",
+    title: "SakumimiDB",
+    description:
+      "櫻坂46のWEBラジオ「さくみみ」の検索用アプリケーション。",
+    images: [`${baseUrl}/logo.png`],
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
close #26 

# やったこと
- OGP設定の追加(openGraph, twitter)
  - 画像はとりあえずロゴ画像を設定
- vercelの `NEXT_PUBLIC_BASE_URL` 環境変数を設定済
  - https://vercel.com/firefoxcrystalgeyser0256-7346s-projects/sakumimi-db/settings/environment-variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SNSシェア表示を拡張しました。Open GraphおよびTwitter Cardに対応し、シェア時にタイトル・説明・画像・URLが適切に表示されます。
  * サイト説明文を微修正しました（末尾の表現を調整）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->